### PR TITLE
Update cdk-deploy.yaml

### DIFF
--- a/.github/workflows/cdk-deploy.yaml
+++ b/.github/workflows/cdk-deploy.yaml
@@ -56,6 +56,12 @@ on:
         type: boolean
         required: false
         default: false
+        
+      RUN_INTEGRATION_TESTS:
+        type: boolean
+        required: false
+        default: false
+        description: "should integration tests be run on this environment?  typically false for preprod/production and true everywhere else"
 
     secrets:
       # only required if using cloudflare provider
@@ -149,6 +155,11 @@ jobs:
         run: |
           cd ${{ inputs.YARN_FOLDER_NAME }}
           yarn pipeline:global:deploy
+          
+      - name: Integration Tests
+        if: "${{inputs.RUN_INTEGRATION_TESTS != '' }}"
+        run: |
+          yarn pipeline:test-int
 
       - name: Slack CDK Complete
         if: "${{ inputs.SLACK_CHANNEL_ID != '' }}"


### PR DESCRIPTION
Both changes pulled from already working cdk-tf-deploy.yaml

added "RUN_INTEGRATION_TESTS" variable
added integrations run after cdk deploy global