### PR TITLE
Support modern versions of yarn

### DIFF
--- a/.github/workflows/cdk-deploy.yaml
+++ b/.github/workflows/cdk-deploy.yaml
@@ -41,6 +41,12 @@ on:
         type: string
         required: true
 
+      YARN_VERSION:
+        type: string
+        required: false
+        default: "4.2.2"
+        description: "version of yarn, ex: classic, latest, stable, 4.x.x"
+
       YARN_DEPLOY_COMMAND:
         type: string
         required: true
@@ -134,15 +140,22 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }} # matches github-torus-packages - repo, packages
 
-      - name: use github as yarn registry
+      - name: setup node
         uses: actions/setup-node@v4
         with:
           node-version: ${{inputs.NODE_VERSION}}
-          registry-url: 'https://npm.pkg.github.com/'
-          always-auth: true
-          scope: '@torusco'
-          cache: 'yarn'      
-          
+          cache: 'yarn'
+
+      - name: setup yarn and github registry
+        run: |
+          corepack enable
+          yarn set version ${{ inputs.YARN_VERSION }}
+          yarn config set npmScopes.torusco.npmRegistryServer "https://npm.pkg.github.com"
+          yarn config set npmScopes.torusco.npmAlwaysAuth true
+          yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: yarn install && yarn build
         run: |
           cd ${{ inputs.YARN_FOLDER_NAME }}
@@ -160,7 +173,7 @@ jobs:
         with:
             role-to-assume: ${{inputs.TARGET_AWS_ACCOUNT_ROLE_ARN}}
             aws-region: ${{inputs.AWS_REGION}}
-  
+
       - name: Slack CDK Start
         id: slack
         if: "${{ inputs.SLACK_CHANNEL_ID != '' }}"
@@ -178,7 +191,7 @@ jobs:
         run: |
           cd ${{ inputs.YARN_FOLDER_NAME }}
           ${{ inputs.YARN_DEPLOY_COMMAND }}
-          
+
       - name: Slack CDK Complete
         if: "${{ inputs.SLACK_CHANNEL_ID != '' }}"
         uses: slackapi/slack-github-action@v1.25.0

--- a/.github/workflows/cdk-deploy.yaml
+++ b/.github/workflows/cdk-deploy.yaml
@@ -134,15 +134,6 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }} # matches github-torus-packages - repo, packages
 
-      - name: setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{inputs.NODE_VERSION}}
-          registry-url: 'https://npm.pkg.github.com/'
-          always-auth: true
-          scope: '@torusco'
-          cache: 'yarn'
-
       - name: setup yarn and github registry
         run: |
           corepack enable
@@ -151,6 +142,15 @@ jobs:
           yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{inputs.NODE_VERSION}}
+          registry-url: 'https://npm.pkg.github.com/'
+          always-auth: true
+          scope: '@torusco'
+          cache: 'yarn'
 
       - name: yarn install && yarn build
         run: |

--- a/.github/workflows/cdk-deploy.yaml
+++ b/.github/workflows/cdk-deploy.yaml
@@ -145,7 +145,6 @@ jobs:
           yarn config set npmScopes.torusco.npmRegistryServer "https://npm.pkg.github.com"
           yarn config set npmScopes.torusco.npmAlwaysAuth true
           yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN
-          yarn --version
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/cdk-deploy.yaml
+++ b/.github/workflows/cdk-deploy.yaml
@@ -146,6 +146,7 @@ jobs:
           yarn config set npmScopes.torusco.npmRegistryServer "https://npm.pkg.github.com"
           yarn config set npmScopes.torusco.npmAlwaysAuth true
           yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN
+          yarn --version
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/cdk-deploy.yaml
+++ b/.github/workflows/cdk-deploy.yaml
@@ -138,6 +138,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{inputs.NODE_VERSION}}
+          registry-url: 'https://npm.pkg.github.com/'
+          always-auth: true
+          scope: '@torusco'
 
       - name: setup yarn and github registry
         run: |

--- a/.github/workflows/cdk-deploy.yaml
+++ b/.github/workflows/cdk-deploy.yaml
@@ -41,12 +41,6 @@ on:
         type: string
         required: true
 
-      YARN_VERSION:
-        type: string
-        required: false
-        default: "4.3.0"
-        description: "version of yarn, ex: classic, latest, stable, 4.x.x"
-
       YARN_DEPLOY_COMMAND:
         type: string
         required: true
@@ -107,7 +101,6 @@ jobs:
           echo RUNS_ON ${{ inputs.RUNS_ON }}
           echo SLACK_CHANNEL_ID ${{ inputs.SLACK_CHANNEL_ID }}
           echo TARGET_AWS_ACCOUNT_ROLE_ARN ${{ inputs.TARGET_AWS_ACCOUNT_ROLE_ARN }}
-          echo YARN_VERSION ${{ inputs.YARN_VERSION }}
           echo YARN_DEPLOY_COMMAND ${{ inputs.YARN_DEPLOY_COMMAND }}
           echo YARN_FOLDER_NAME ${{ inputs.YARN_FOLDER_NAME }}
           echo USES_CLOUDFLARE ${{ inputs.USES_CLOUDFLARE }}
@@ -150,7 +143,6 @@ jobs:
       - name: setup yarn and github registry
         run: |
           corepack enable
-          yarn set version ${{ inputs.YARN_VERSION }}
           yarn config set npmScopes.torusco.npmRegistryServer "https://npm.pkg.github.com"
           yarn config set npmScopes.torusco.npmAlwaysAuth true
           yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN

--- a/.github/workflows/cdk-deploy.yaml
+++ b/.github/workflows/cdk-deploy.yaml
@@ -107,6 +107,7 @@ jobs:
           echo RUNS_ON ${{ inputs.RUNS_ON }}
           echo SLACK_CHANNEL_ID ${{ inputs.SLACK_CHANNEL_ID }}
           echo TARGET_AWS_ACCOUNT_ROLE_ARN ${{ inputs.TARGET_AWS_ACCOUNT_ROLE_ARN }}
+          echo YARN_VERSION ${{ inputs.YARN_VERSION }}
           echo YARN_DEPLOY_COMMAND ${{ inputs.YARN_DEPLOY_COMMAND }}
           echo YARN_FOLDER_NAME ${{ inputs.YARN_FOLDER_NAME }}
           echo USES_CLOUDFLARE ${{ inputs.USES_CLOUDFLARE }}

--- a/.github/workflows/cdk-deploy.yaml
+++ b/.github/workflows/cdk-deploy.yaml
@@ -44,7 +44,7 @@ on:
       YARN_VERSION:
         type: string
         required: false
-        default: "4.2.2"
+        default: "4.3.0"
         description: "version of yarn, ex: classic, latest, stable, 4.x.x"
 
       YARN_DEPLOY_COMMAND:

--- a/.github/workflows/cdk-deploy.yaml
+++ b/.github/workflows/cdk-deploy.yaml
@@ -141,6 +141,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
           always-auth: true
           scope: '@torusco'
+          cache: 'yarn'
 
       - name: setup yarn and github registry
         run: |

--- a/.github/workflows/cdk-deploy.yaml
+++ b/.github/workflows/cdk-deploy.yaml
@@ -138,7 +138,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{inputs.NODE_VERSION}}
-          cache: 'yarn'
 
       - name: setup yarn and github registry
         run: |

--- a/.github/workflows/cdk-diff.yaml
+++ b/.github/workflows/cdk-diff.yaml
@@ -28,7 +28,7 @@ on:
       YARN_VERSION:
         type: string
         required: false
-        default: "4.2.2"
+        default: "4.3.0"
         description: "version of yarn, ex: classic, latest, stable, 4.x.x"
 
       RUNS_ON:

--- a/.github/workflows/cdk-diff.yaml
+++ b/.github/workflows/cdk-diff.yaml
@@ -81,6 +81,7 @@ jobs:
           yarn config set npmScopes.torusco.npmRegistryServer "https://npm.pkg.github.com"
           yarn config set npmScopes.torusco.npmAlwaysAuth true
           yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN
+          yarn --version
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/cdk-diff.yaml
+++ b/.github/workflows/cdk-diff.yaml
@@ -76,6 +76,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
           always-auth: true
           scope: '@torusco'
+          cache: 'yarn'
 
       - name: setup yarn and github registry
         run: |

--- a/.github/workflows/cdk-diff.yaml
+++ b/.github/workflows/cdk-diff.yaml
@@ -69,6 +69,7 @@ jobs:
           echo NODE_VERSION ${{ inputs.NODE_VERSION }}
           echo RUNS_ON ${{ inputs.RUNS_ON }}
           echo TARGET_AWS_ACCOUNT_ROLE_ARN ${{ inputs.TARGET_AWS_ACCOUNT_ROLE_ARN }}
+          echo YARN_VERSION ${{ inputs.YARN_VERSION }}
           echo YARN_DIFF_COMMAND ${{ inputs.YARN_DIFF_COMMAND }}
 
       - uses: actions/checkout@v4

--- a/.github/workflows/cdk-diff.yaml
+++ b/.github/workflows/cdk-diff.yaml
@@ -73,6 +73,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{inputs.NODE_VERSION}}
+          registry-url: 'https://npm.pkg.github.com/'
+          always-auth: true
+          scope: '@torusco'
 
       - name: setup yarn and github registry
         run: |

--- a/.github/workflows/cdk-diff.yaml
+++ b/.github/workflows/cdk-diff.yaml
@@ -24,12 +24,18 @@ on:
         type: string
         required: false
         default: '20.x'
-  
+
+      YARN_VERSION:
+        type: string
+        required: false
+        default: "4.2.2"
+        description: "version of yarn, ex: classic, latest, stable, 4.x.x"
+
       RUNS_ON:
         type: string
         required: false
         default: ubuntu-latest-8-cores
-  
+
       TARGET_AWS_ACCOUNT_ROLE_ARN:
         type: string
         required: true
@@ -69,15 +75,22 @@ jobs:
         with: 
           token: ${{ secrets.NPM_TOKEN }} # matches github-torus-packages - repo, packages
 
-      - name: use github as yarn registry
+      - name: setup node
         uses: actions/setup-node@v4
         with:
           node-version: ${{inputs.NODE_VERSION}}
-          registry-url: 'https://npm.pkg.github.com/'
-          always-auth: true
-          scope: '@torusco'
-          cache: 'yarn'      
-  
+          cache: 'yarn'
+
+      - name: setup yarn and github registry
+        run: |
+          corepack enable
+          yarn set version ${{ inputs.YARN_VERSION }}
+          yarn config set npmScopes.torusco.npmRegistryServer "https://npm.pkg.github.com"
+          yarn config set npmScopes.torusco.npmAlwaysAuth true
+          yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: yarn install && yarn build
         run: |
           yarn install
@@ -98,5 +111,3 @@ jobs:
       - name: CDK Diff
         run: |
           ${{ inputs.YARN_DIFF_COMMAND }}
-
-

--- a/.github/workflows/cdk-diff.yaml
+++ b/.github/workflows/cdk-diff.yaml
@@ -69,15 +69,6 @@ jobs:
         with: 
           token: ${{ secrets.NPM_TOKEN }} # matches github-torus-packages - repo, packages
 
-      - name: setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{inputs.NODE_VERSION}}
-          registry-url: 'https://npm.pkg.github.com/'
-          always-auth: true
-          scope: '@torusco'
-          cache: 'yarn'
-
       - name: setup yarn and github registry
         run: |
           corepack enable
@@ -86,6 +77,15 @@ jobs:
           yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{inputs.NODE_VERSION}}
+          registry-url: 'https://npm.pkg.github.com/'
+          always-auth: true
+          scope: '@torusco'
+          cache: 'yarn'
 
       - name: yarn install && yarn build
         run: |

--- a/.github/workflows/cdk-diff.yaml
+++ b/.github/workflows/cdk-diff.yaml
@@ -80,7 +80,6 @@ jobs:
           yarn config set npmScopes.torusco.npmRegistryServer "https://npm.pkg.github.com"
           yarn config set npmScopes.torusco.npmAlwaysAuth true
           yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN
-          yarn --version
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/cdk-diff.yaml
+++ b/.github/workflows/cdk-diff.yaml
@@ -25,12 +25,6 @@ on:
         required: false
         default: '20.x'
 
-      YARN_VERSION:
-        type: string
-        required: false
-        default: "4.3.0"
-        description: "version of yarn, ex: classic, latest, stable, 4.x.x"
-
       RUNS_ON:
         type: string
         required: false
@@ -69,7 +63,6 @@ jobs:
           echo NODE_VERSION ${{ inputs.NODE_VERSION }}
           echo RUNS_ON ${{ inputs.RUNS_ON }}
           echo TARGET_AWS_ACCOUNT_ROLE_ARN ${{ inputs.TARGET_AWS_ACCOUNT_ROLE_ARN }}
-          echo YARN_VERSION ${{ inputs.YARN_VERSION }}
           echo YARN_DIFF_COMMAND ${{ inputs.YARN_DIFF_COMMAND }}
 
       - uses: actions/checkout@v4
@@ -85,7 +78,6 @@ jobs:
       - name: setup yarn and github registry
         run: |
           corepack enable
-          yarn set version ${{ inputs.YARN_VERSION }}
           yarn config set npmScopes.torusco.npmRegistryServer "https://npm.pkg.github.com"
           yarn config set npmScopes.torusco.npmAlwaysAuth true
           yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN

--- a/.github/workflows/cdk-diff.yaml
+++ b/.github/workflows/cdk-diff.yaml
@@ -73,7 +73,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{inputs.NODE_VERSION}}
-          cache: 'yarn'
 
       - name: setup yarn and github registry
         run: |

--- a/.github/workflows/cdk-test.yaml
+++ b/.github/workflows/cdk-test.yaml
@@ -116,7 +116,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{inputs.NODE_VERSION}}
-          cache: 'yarn'
 
       - name: setup yarn and github registry
         run: |

--- a/.github/workflows/cdk-test.yaml
+++ b/.github/workflows/cdk-test.yaml
@@ -123,7 +123,6 @@ jobs:
           yarn config set npmScopes.torusco.npmRegistryServer "https://npm.pkg.github.com"
           yarn config set npmScopes.torusco.npmAlwaysAuth true
           yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN
-          yarn --version
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   

--- a/.github/workflows/cdk-test.yaml
+++ b/.github/workflows/cdk-test.yaml
@@ -33,7 +33,7 @@ on:
       YARN_VERSION:
         type: string
         required: false
-        default: "4.2.2"
+        default: "4.3.0"
         description: "version of yarn, ex: classic, latest, stable, 4.x.x"
 
       YARN_EXPORTS_COMMAND:

--- a/.github/workflows/cdk-test.yaml
+++ b/.github/workflows/cdk-test.yaml
@@ -30,12 +30,6 @@ on:
         required: false
         default: ''
 
-      YARN_VERSION:
-        type: string
-        required: false
-        default: "4.3.0"
-        description: "version of yarn, ex: classic, latest, stable, 4.x.x"
-
       YARN_EXPORTS_COMMAND:
         type: string
         required: false
@@ -90,7 +84,6 @@ jobs:
           echo AWS_REGION ${{ inputs.AWS_REGION }}
           echo CDK_PREFIX ${{ inputs.CDK_PREFIX }}
           echo TARGET_AWS_ACCOUNT_ROLE_ARN ${{ inputs.TARGET_AWS_ACCOUNT_ROLE_ARN }}
-          echo YARN_VERSION ${{ inputs.YARN_VERSION }}
           echo YARN_EXPORTS_COMMAND ${{ inputs.YARN_EXPORTS_COMMAND }}
           echo YARN_TEST_COMMAND ${{ inputs.YARN_TEST_COMMAND }}
           echo USES_SONAR_CLOUD ${{ inputs.USES_SONAR_CLOUD }}
@@ -128,7 +121,6 @@ jobs:
       - name: setup yarn and github registry
         run: |
           corepack enable
-          yarn set version ${{ inputs.YARN_VERSION }}
           yarn config set npmScopes.torusco.npmRegistryServer "https://npm.pkg.github.com"
           yarn config set npmScopes.torusco.npmAlwaysAuth true
           yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN

--- a/.github/workflows/cdk-test.yaml
+++ b/.github/workflows/cdk-test.yaml
@@ -90,6 +90,7 @@ jobs:
           echo AWS_REGION ${{ inputs.AWS_REGION }}
           echo CDK_PREFIX ${{ inputs.CDK_PREFIX }}
           echo TARGET_AWS_ACCOUNT_ROLE_ARN ${{ inputs.TARGET_AWS_ACCOUNT_ROLE_ARN }}
+          echo YARN_VERSION ${{ inputs.YARN_VERSION }}
           echo YARN_EXPORTS_COMMAND ${{ inputs.YARN_EXPORTS_COMMAND }}
           echo YARN_TEST_COMMAND ${{ inputs.YARN_TEST_COMMAND }}
           echo USES_SONAR_CLOUD ${{ inputs.USES_SONAR_CLOUD }}

--- a/.github/workflows/cdk-test.yaml
+++ b/.github/workflows/cdk-test.yaml
@@ -112,15 +112,6 @@ jobs:
         with: 
           token: ${{ secrets.NPM_TOKEN }} # matches github-torus-packages - repo, packages
 
-      - name: setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{inputs.NODE_VERSION}}
-          registry-url: 'https://npm.pkg.github.com/'
-          always-auth: true
-          scope: '@torusco'
-          cache: 'yarn'
-
       - name: setup yarn and github registry
         run: |
           corepack enable
@@ -129,6 +120,15 @@ jobs:
           yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{inputs.NODE_VERSION}}
+          registry-url: 'https://npm.pkg.github.com/'
+          always-auth: true
+          scope: '@torusco'
+          cache: 'yarn'
   
       - name: yarn install && yarn build
         run: |

--- a/.github/workflows/cdk-test.yaml
+++ b/.github/workflows/cdk-test.yaml
@@ -116,6 +116,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{inputs.NODE_VERSION}}
+          registry-url: 'https://npm.pkg.github.com/'
+          always-auth: true
+          scope: '@torusco'
 
       - name: setup yarn and github registry
         run: |

--- a/.github/workflows/cdk-test.yaml
+++ b/.github/workflows/cdk-test.yaml
@@ -14,7 +14,7 @@ on:
         type: string
         required: false
         default: ubuntu-latest-8-cores
-      
+
       AWS_REGION:
         type: string
         required: false
@@ -30,6 +30,12 @@ on:
         required: false
         default: ''
 
+      YARN_VERSION:
+        type: string
+        required: false
+        default: "4.2.2"
+        description: "version of yarn, ex: classic, latest, stable, 4.x.x"
+
       YARN_EXPORTS_COMMAND:
         type: string
         required: false
@@ -44,7 +50,7 @@ on:
         required: false
         default: false
         description: "should integration tests be run on this environment?"
-      
+
       USES_SONAR_CLOUD:
         type: boolean
         default: true
@@ -69,7 +75,7 @@ jobs:
   cdk_test:
 
     runs-on: ${{ inputs.RUNS_ON }}
-    
+
     permissions: # github oidc
       id-token: write
       contents: read
@@ -112,19 +118,21 @@ jobs:
         with: 
           token: ${{ secrets.NPM_TOKEN }} # matches github-torus-packages - repo, packages
 
-      - name: use github as yarn registry
+      - name: setup node
         uses: actions/setup-node@v4
         with:
           node-version: ${{inputs.NODE_VERSION}}
-          registry-url: 'https://npm.pkg.github.com/'
-          always-auth: true
-          scope: '@torusco'
-          cache: 'yarn' 
-          
-      - name: CDK Prefix
-        if: "${{ inputs.USES_INTEGRATION_EXPORTS == true }}"
+          cache: 'yarn'
+
+      - name: setup yarn and github registry
         run: |
-          echo "CDK_PREFIX=${{ inputs.CDK_PREFIX }}" >> $GITHUB_ENV
+          corepack enable
+          yarn set version ${{ inputs.YARN_VERSION }}
+          yarn config set npmScopes.torusco.npmRegistryServer "https://npm.pkg.github.com"
+          yarn config set npmScopes.torusco.npmAlwaysAuth true
+          yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   
       - name: yarn install && yarn build
         run: |
@@ -132,6 +140,11 @@ jobs:
           yarn build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: CDK Prefix
+        if: "${{ inputs.USES_INTEGRATION_EXPORTS == true }}"
+        run: |
+          echo "CDK_PREFIX=${{ inputs.CDK_PREFIX }}" >> $GITHUB_ENV
 
       - name: Deployer Role with OIDC Provider
         if: "${{ inputs.USES_INTEGRATION_EXPORTS == true }}"

--- a/.github/workflows/cdk-test.yaml
+++ b/.github/workflows/cdk-test.yaml
@@ -119,6 +119,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
           always-auth: true
           scope: '@torusco'
+          cache: 'yarn'
 
       - name: setup yarn and github registry
         run: |

--- a/.github/workflows/cdk-test.yaml
+++ b/.github/workflows/cdk-test.yaml
@@ -124,6 +124,7 @@ jobs:
           yarn config set npmScopes.torusco.npmRegistryServer "https://npm.pkg.github.com"
           yarn config set npmScopes.torusco.npmAlwaysAuth true
           yarn config set npmScopes.torusco.npmAuthToken $NPM_AUTH_TOKEN
+          yarn --version
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 # v?
 
 * Allow specifying yarn version
-* YARN_VERSION default is 4.2.2, is not required, and can be overridden
+* YARN_VERSION default is 4.3.0, is not required, and can be overridden
 
 # v8
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@
 * branches are named: v6, v7.1, v8, etc and they are not deleted when PRs are merged
 * PRs are only created when making a new major version to push the latest version to main before creating the new branch
 
-# v?
+# v9
 
-* Allow specifying yarn version
-* YARN_VERSION default is 4.3.0, is not required, and can be overridden
+* Convert to using modern version of yarn
 
 # v8
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@
 * branches are named: v6, v7.1, v8, etc and they are not deleted when PRs are merged
 * PRs are only created when making a new major version to push the latest version to main before creating the new branch
 
-# v9
-
-* Support modern version of yarn using corepack
-
 # v8
 
 * based on v7.3
@@ -20,6 +16,7 @@
 * PY_VERSION python default is now 3.11 by default, is not required, and can be overridden
 * NODE_VERSION node default is now 20 by default, is not required, and can be overridden
 * RUNS_ON for cdk defaults to 8 cores, and latest for all others, is no longer required, and can be overridden
+* Support modern version of yarn using corepack
 
 ## steps to migrate to this version
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,19 @@
 * branches are named: v6, v7.1, v8, etc and they are not deleted when PRs are merged
 * PRs are only created when making a new major version to push the latest version to main before creating the new branch
 
+# v?
+
+* Allow specifying yarn version
+* YARN_VERSION default is 4.2.2, is not required, and can be overridden
+
 # v8
 
 * based on v7.3
 * switch to github oidc provider (remove SAML and saml.to)
-* TERRAFORM_VERSION terraform default is now 1.6.6 by default, is not required, and can be overriden
-* PY_VERSION python default is now 3.11 by default, is not required, and can be overriden
-* NODE_VERSION node default is now 20 by default, is not required, and can be overriden
-* RUNS_ON for cdk defaults to 8 cores, and latest for all others, is no longer required, and can be overriden
+* TERRAFORM_VERSION terraform default is now 1.6.6 by default, is not required, and can be overridden
+* PY_VERSION python default is now 3.11 by default, is not required, and can be overridden
+* NODE_VERSION node default is now 20 by default, is not required, and can be overridden
+* RUNS_ON for cdk defaults to 8 cores, and latest for all others, is no longer required, and can be overridden
 
 ## steps to migrate to this version
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 # v9
 
-* Convert to using modern version of yarn
+* Support modern version of yarn using corepack
 
 # v8
 


### PR DESCRIPTION
This PR adds support for modern versions of yarn using [corepack](https://nodejs.org/docs/latest-v20.x/api/corepack.html), while maintaining backwards compatibility with yarn classic we are using today.

## Changes 

- Supports modern versions of yarn using [corepack](https://nodejs.org/docs/latest-v20.x/api/corepack.html)
- Sets the package scope registry for modern yarn versions
- Backwards compatible with yarn classic (1.x)

Updating a repo to using the latest version of yarn is as simple as running `corepack use yarn@latest` which adds `"packageManager": "yarn@4.3.0"` to the repos `package.json` file and regenerates the `yarn.lock`. For more info see [confluence document](https://torusco.atlassian.net/wiki/spaces/PRODUCT/pages/887980071/Yarn+4+Upgrade)

## Example workflow runs

- No changes to repo, using yarn classic: https://github.com/torusco/location/pull/177 / https://github.com/torusco/location/actions/runs/9468087971/job/26083658801
- Using latest yarn 4.3.0: https://github.com/torusco/weather/pull/122 / https://github.com/torusco/weather/actions/runs/9468127017/job/26083781218